### PR TITLE
Fix session logout in authentication middleware

### DIFF
--- a/middleware/authenticate.js
+++ b/middleware/authenticate.js
@@ -19,7 +19,7 @@ const authenticate = (req, res, next) => {
         res.clearCookie('123456cat');
         res.clearCookie(process.env.ACCESS_TOKEN_SECRET);
         res.clearCookie(process.env.REFRESH_TOKEN_SECRET);
-        req.session.loggedin === false
+        req.session.loggedin = false;
         res.redirect('/')
         // res.json({
         //     message: 'Authentication failed'


### PR DESCRIPTION
## Summary
- Correct session assignment when authentication fails

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68969094fda8832ebec23038b08e055f